### PR TITLE
Add support for MacOS 12+

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,8 @@ import PackageDescription
 let package = Package(
     name: "SymSpellSwift",
     platforms: [
-        .iOS(.v15)
+        .iOS(.v15),
+        .macOS(.v12),
     ],
     products: [
         .library(


### PR DESCRIPTION
Just a simple oneline change to enable support for MacOS.

I chose 12+, as lower versions do not support the 2 usages of `url.lines` in [SymSpell.swift](Sources/SymSpellSwift/SymSpell.swift).