### PR TITLE
Added missing public annotations in SymSpell.Segmentaion type

### DIFF
--- a/Sources/SymSpellSwift/SymSpell.swift
+++ b/Sources/SymSpellSwift/SymSpell.swift
@@ -17,10 +17,10 @@ public class SymSpell {
     }
     
     public struct Segmentation {
-        var segmentedString = ""
-        var correctedString = ""
-        var distanceSum = 0
-        var probabilityLogSum = 0.0
+        public var segmentedString = ""
+        public var correctedString = ""
+        public var distanceSum = 0
+        public var probabilityLogSum = 0.0
     }
     
     public var wordCount: Int { words.count }


### PR DESCRIPTION
SymSpell.Segmentations properties are were not marked public, making the result of methods like SymSpell.wordSegmentation() useless, if SymSpell is imported as a separate module.

Issue #2